### PR TITLE
fix: add invalidExts as an option

### DIFF
--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -1,13 +1,14 @@
 import type { StylexOptions, UnpluginStylexOptions } from '@/types'
 import { isDevelopment } from './constants'
 
-export function getOptions(options: UnpluginStylexOptions) {
+export function getOptions(options: UnpluginStylexOptions): Required<UnpluginStylexOptions> {
   const stylex = options.stylex || ({} as StylexOptions)
   const isDev = options.dev || isDevelopment
 
   return {
     ...options,
     dev: options.dev || isDev,
+    invalidExts: ['.json', '.html', '.jade', '.json5', ...(options.invalidExts ?? [])],
     stylex: {
       filename: stylex.filename || 'stylex.css',
       stylexImports: stylex.stylexImports || ['@stylexjs/stylex'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexOptions | undefined>
 
     transformInclude(id) {
       // webpack will contain these files, which will occur errors
-      const invalidExts = ['.json', '.html', '.jade', '.json5']
+      const invalidExts = options.invalidExts
       const extname = path.extname(id)
       // for handle vite
       const questionMarkIndex = extname.indexOf('?')

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export type StylexOptions = {
   stylexImports?: string[]
   classNamePrefix?: string
   unstable_moduleResolution?: {
-    type: 'commonjs' | 'haste'
+    type: 'commonJS' | 'haste'
     rootDir: string
   }
   babelConfig?: BabelConfig
@@ -21,9 +21,10 @@ export type StylexOptions = {
 }
 
 export type UnpluginStylexOptions = {
-  compiler?: string
+  // compiler?: string
+  invalidExts?: string[]
   dev?: boolean
-  enforce?: 'post' | 'pre'
+  // enforce?: 'post' | 'pre'
   stylex?: StylexOptions
 }
 


### PR DESCRIPTION
Also
* places stricter type restriction when using options internally
* removes unused options since default values are not clear

fixes eryue0220/unplugin-stylex#39