### PR TITLE
Move devDep into devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,13 +98,13 @@
     "@rollup/pluginutils": "^5.1.4",
     "@stylexjs/babel-plugin": "^0.16.0",
     "@types/node": "^24.0.15",
-    "@vitest/coverage-v8": "^3.2.4",
     "unplugin": "^1.16.1"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.29.2",
+    "@vitest/coverage-v8": "^3.2.4",
     "babel-plugin-syntax-hermes-parser": "^0.19.2",
     "jsr": "^0.13.4",
     "tsup": "^8.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       '@types/node':
         specifier: ^24.0.15
         version: 24.0.15
-      '@vitest/coverage-v8':
-        specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@24.0.15)(jiti@2.4.2)(terser@5.39.0))
       unplugin:
         specifier: ^1.16.1
         version: 1.16.1
@@ -48,6 +45,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.2
         version: 2.29.2
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@24.0.15)(jiti@2.4.2)(terser@5.39.0))
       babel-plugin-syntax-hermes-parser:
         specifier: ^0.19.2
         version: 0.19.2


### PR DESCRIPTION
Noticed this warning in my project. I assume we dont need this for the prod version

<img width="386" height="104" alt="CleanShot 2025-10-25 at 11 02 51" src="https://github.com/user-attachments/assets/3cfd0916-636a-474d-8ca7-46c89d4e75ac" />
